### PR TITLE
Updated dockerfile to use updated image and ES curator in support of …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # Docker Definition for ElasticSearch Curator
 
-FROM ubuntu:16.04
-MAINTAINER Deirdre Storck <deirdre.storck@gmail.com>
+FROM ubuntu:17.10
+LABEL MAINTAINER="Deirdre Storck <deirdre.storck@gmail.com>, Jim Conner <snafu.x@gmail.com>" \
+      DESCRIPTION="Docker definition file for elasticsearch curator to be used with Samsung SDS ElasticSearch Chart"
 
 RUN buildDeps='python-pip' && \
     apt-get -qq update && \
     apt-get install -y -qq $buildDeps && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --quiet elasticsearch-curator==5.2.0 && \
+RUN pip install --quiet elasticsearch-curator==5.5.1 && \
 		apt-get remove --purge --auto-remove -y -qq $buildDeps binutils perl
 
 ENTRYPOINT [ "/usr/local/bin/curator" ]


### PR DESCRIPTION
…the update to ES container reference CO-217

**What this PR does / why we need it**:
Updates Ubuntu image to 17.10 and allows support for latest version of curator to support newer version of ES (5.6.3)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # CO-217

**Special notes for your reviewer**:

